### PR TITLE
Cache Fixes

### DIFF
--- a/faceReidDatasets/datasets.py
+++ b/faceReidDatasets/datasets.py
@@ -116,6 +116,8 @@ class ReadableMultiLevelDatasetBase(MutiLevelDatasetBase, abc.ABC):
 
         # Read / Store in the cache.
         try:
+            cache_directory = os.path.expanduser(cache_directory)
+            cache_directory = os.path.abspath(cache_directory)
             cache_path = os.path.join(cache_directory,
                                       dataset_name + ".pickle")
             with open(cache_path, "rb") as f:

--- a/faceReidDatasets/datasets.py
+++ b/faceReidDatasets/datasets.py
@@ -12,7 +12,7 @@ from typing import List, Set, Tuple
 ingrediant = sacred.Ingredient("dataset")
 
 
-class DatasetBase(abc.ABC, collections.abc.Sequence):
+class DatasetBase(collections.abc.Sequence):
     """
     #TODO
     """
@@ -121,18 +121,49 @@ class ReadableMultiLevelDatasetBase(MutiLevelDatasetBase, abc.ABC):
             cache_path = os.path.join(cache_directory,
                                       dataset_name + ".pickle")
             with open(cache_path, "rb") as f:
-                return pickle.load(f)
+                # Prefix dataset directory.
+                scrubbed_dataset = pickle.load(f)
+                return self._prefix_dataset_directory(scrubbed_dataset)
+
         except FileNotFoundError:
             dataset = self._read_dataset()
             try:
+                # Scrub dataset of dataset_directory.
+                scrubbed_dataset = self._scrub_dataset_directory(dataset)
                 with open(cache_path, 'wb') as f:
-                    pickle.dump(dataset, f)
+                    pickle.dump(scrubbed_dataset, f)
             finally:
                 return dataset
 
     @abc.abstractmethod
     def _read_dataset(self):
         pass
+
+    def _scrub_dataset_directory(self, dataset):
+
+        def scrub(dataset):
+            scrubbed_samples = []
+            for sample in dataset:
+                scrubbed_samples.append(
+                    (sample[0].replace(self.dataset_directory, ""), sample[1]))
+            return scrubbed_samples
+
+        return self._traverse(dataset, scrub)
+
+    def _prefix_dataset_directory(self, dataset):
+
+        def prefix(dataset):
+            prefixed_samples = []
+            for sample in dataset:
+                prefixed_samples.append(
+                    (
+                        os.path.join(self.dataset_directory, sample[0]),
+                        sample[1]
+                    )
+                )
+            return prefixed_samples
+
+        return self._traverse(dataset, prefix)
 
 
 class VGGFace2(ReadableMultiLevelDatasetBase):

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -207,3 +207,8 @@ class SyntheticTests(unittest.TestCase):
         dataset2 = datasets.Synthetic(self.dataset_directory,
                                       cache_directory=cache_dir)
         self.assertEqual(len(dataset2.dataset["test"]), 0)
+
+        # Check paths are correct.
+        self.assertTrue(os.path.exists(dataset2["train"][0][0]))
+        self.assertTrue(os.path.exists(dataset2["train"][1][0]))
+        self.assertTrue(os.path.exists(dataset2["train"][2][0]))


### PR DESCRIPTION
Fixes:
- Cache path was not resoved to absolute path, thereby creating subdirectories with the name ```~```.

Improvements:
- The root datasets directory is scrubbed from the paths while caching a dataset: this allows the same cache to be used for both docker and non-docker executions.